### PR TITLE
Add ffaker dependency to gemspec

### DIFF
--- a/solidus_prototypes.gemspec
+++ b/solidus_prototypes.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rspec', '~> 1.8'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'ffaker'
 end


### PR DESCRIPTION
ffaker was removed as a runtime dependency of Solidus here:
https://github.com/solidusio/solidus/pull/2163