### PR TITLE
Test suite maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 sudo: false
 cache: bundler
 language: ruby
+addons:
+  chrome: stable
+  apt:
+    packages:
+      - chromium-chromedriver
 rvm:
   - 2.5
 before_install:
   - gem update --system
   - gem install bundler
+  - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver
 env:
   matrix:
     - SOLIDUS_BRANCH=v2.3 DB=postgres

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem 'solidus', github: 'solidusio/solidus', branch: branch
+gem 'solidus', git: 'https://github.com/solidusio/solidus.git', branch: branch
 gem 'solidus_auth_devise', '~> 1.0'
 
 if branch == 'master' || branch >= "v2.3"

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', git: 'https://github.com/solidusio/solidus.git', branch: branch
 gem 'solidus_auth_devise', '~> 1.0'
+gem 'solidus_support', git: 'https://github.com/solidusio/solidus_support.git', branch: 'master'
 
 if ENV['DB'] == 'mysql'
   gem 'mysql2'

--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,6 @@ branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', git: 'https://github.com/solidusio/solidus.git', branch: branch
 gem 'solidus_auth_devise', '~> 1.0'
 
-if branch == 'master' || branch >= "v2.3"
-  gem 'rails', '~> 5.1.0' # HACK: broken bundler dependency resolution
-elsif branch >= "v2.0"
-  gem 'rails', '~> 5.0.0' # HACK: broken bundler dependency resolution
-end
-
 if ENV['DB'] == 'mysql'
   gem 'mysql2'
 else

--- a/app/views/spree/admin/prototypes/_prototypes.html.erb
+++ b/app/views/spree/admin/prototypes/_prototypes.html.erb
@@ -14,12 +14,12 @@
       <tr id="row_<%= prototype.id %>" data-hook="available_row" class="<%= cycle('odd', 'even')%>">
         <td><%= prototype.name %></td>
         <td class="actions">
-          <%= link_to Spree.t(:select), select_admin_prototype_url(prototype), class: 'ajax button select_properties_from_prototype', data: { remote: true } %>
+          <%= link_to I18n.t('spree.select'), select_admin_prototype_url(prototype), class: 'ajax button select_properties_from_prototype', data: { remote: true } %>
         </td>
       </tr>
     <% end %>
     <% if @prototypes.empty? %>
-     <tr data-hook="available_none"><td colspan="2"><% Spree.t(:none) %>.</td></tr>
+     <tr data-hook="available_none"><td colspan="2"><% I18n.t('spree.none') %>.</td></tr>
     <% end %>
   </tbody>
 </table>

--- a/app/views/spree/admin/prototypes/index.html.erb
+++ b/app/views/spree/admin/prototypes/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Prototype) %>
     <li id="new_prototype_link">
-      <%= button_link_to Spree.t(:new_prototype), new_admin_prototype_url, {:remote => true, :id => 'new_prototype_link'} %>
+      <%= link_to I18n.t('spree.new_prototype'), new_admin_prototype_url, {:remote => true, :id => 'new_prototype_link'} %>
     </li>
   <% end %>
 <% end %>

--- a/app/views/spree/admin/prototypes/new.html.erb
+++ b/app/views/spree/admin/prototypes/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for [:admin, @prototype] do |f| %>
 <fieldset data-hook="new_prototype">
-  <legend align="center"><%= Spree.t(:new_prototype) %></legend>
+  <legend align="center"><%= I18n.t('spree.new_prototype') %></legend>
   <%= render :partial => 'form', :locals => { :f => f } %>
   <%= render :partial => 'spree/admin/shared/new_resource_links' %>
 </fieldset>

--- a/app/views/spree/shared/_prototypes_product_properties_toolbar.html.erb
+++ b/app/views/spree/shared/_prototypes_product_properties_toolbar.html.erb
@@ -1,5 +1,5 @@
 <li>
   <span id="new_ptype_link">
-    <%= link_to Spree.t(:select_from_prototype), available_admin_prototypes_url, :remote => true, :class => 'button fa fa-copy' %>
+    <%= link_to I18n.t('spree.select_from_prototype'), available_admin_prototypes_url, :remote => true, :class => 'button fa fa-copy' %>
   </span>
 </li>

--- a/solidus_prototypes.gemspec
+++ b/solidus_prototypes.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'solidus_core', ['>= 2.1.0.alpha', '< 3']
-  s.add_dependency 'solidus_support'
 
   s.add_development_dependency 'capybara', '~> 2.18'
   s.add_development_dependency 'capybara-screenshot'
@@ -24,11 +23,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rubocop', '0.52.0'
   s.add_development_dependency 'rubocop-rspec', '~> 1.8'
   s.add_development_dependency 'sass-rails'
+  s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
 end

--- a/spec/features/admin/products/prototypes_spec.rb
+++ b/spec/features/admin/products/prototypes_spec.rb
@@ -99,10 +99,8 @@ describe "Prototypes", type: :feature do
     click_link "Prototypes"
 
     within("#spree_prototype_#{shirt_prototype.id}") do
-      page.find('.delete-resource').click
+      accept_confirm { find('.delete-resource').click }
     end
-
-    page.evaluate_script('window.confirm = function() { return true; }')
 
     expect(page).to have_content("Prototype \"#{shirt_prototype.name}\" has been successfully removed!")
   end

--- a/spec/features/admin/prototypes_products_spec.rb
+++ b/spec/features/admin/prototypes_products_spec.rb
@@ -56,9 +56,9 @@ describe "Products", type: :feature do
         fill_in "product_name", with: "Baseball Cap"
         fill_in "product_sku", with: "B100"
         fill_in "product_price", with: "100"
-        fill_in "product_available_on", with: "2012/01/24"
         select "Size", from: "Prototype"
         check "Large"
+        fill_in "product_available_on", with: "2012/01/24"
         select @shipping_category.name, from: "product_shipping_category_id"
         click_button "Create"
         expect(page).to have_content("successfully created!")


### PR DESCRIPTION
This PR aims to get a green Travis build by:

* Replacing Poltergeist with Headless Chrome (using `solidus_support` latest `master` revision)
* Handling an unexpected browser alert properly

It also removes unnecessary dependencies and fixes all deprecation warnings :tada:

Take into consideration that, once a new Solidus Support gem version is available (acc. to solidusio/solidus_support#17), we should stop using said gem from Git.