### PR TITLE
Fix admin tab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', git: 'https://github.com/solidusio/solidus.git', branch: branch
-gem 'solidus_auth_devise', '~> 1.0'
+gem 'solidus_auth_devise'
 gem 'solidus_support', git: 'https://github.com/solidusio/solidus_support.git', branch: 'master'
 
 if ENV['DB'] == 'mysql'

--- a/lib/solidus_prototypes.rb
+++ b/lib/solidus_prototypes.rb
@@ -1,2 +1,3 @@
 require 'solidus_core'
 require 'solidus_prototypes/engine'
+require 'deface' # must appear below something that requires rails

--- a/lib/solidus_prototypes/version.rb
+++ b/lib/solidus_prototypes/version.rb
@@ -1,3 +1,3 @@
 module SolidusPrototypes
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/solidus_prototypes.gemspec
+++ b/solidus_prototypes.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
+  s.add_dependency 'deface'
   s.add_dependency 'solidus_core', ['>= 2.1.0.alpha', '< 3']
 
   s.add_development_dependency 'capybara', '~> 2.18'


### PR DESCRIPTION
This PR adds Deface as a dependency to fix the admin area overrides, and relaxes the solidus_auth_devise version to fix an error in the admin area.

<img width="437" alt="screen shot 2019-01-08 at 7 54 17 pm" src="https://user-images.githubusercontent.com/1529452/50875893-386db900-137f-11e9-894f-858bc575d508.png">

<img width="712" alt="screen shot 2019-01-08 at 7 13 19 pm" src="https://user-images.githubusercontent.com/1529452/50875965-8a164380-137f-11e9-828e-08080a164200.png">
