### PR TITLE
Lock SQLite3 to version 1.3

### DIFF
--- a/solidus_prototypes.gemspec
+++ b/solidus_prototypes.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
 end


### PR DESCRIPTION
SQLite3 v1.4 was released on February 4th, which breaks compatibility with ActiveRecord's adapter for said DB engine.