### PR TITLE
Fix adding prototypes properties

### DIFF
--- a/app/views/spree/admin/prototypes/select.js.erb
+++ b/app/views/spree/admin/prototypes/select.js.erb
@@ -1,4 +1,4 @@
 <% @prototype_properties.sort_by{ |prop| -prop[:id] }.each do |prop| %>
-  $("a.spree_add_fields").click();
+  $(".spree_add_fields").click();
   $(".product_property.fields:first input[type=text]:first").val("<%= prop.name %>");
 <% end %>

--- a/spec/features/admin/prototypes_products_spec.rb
+++ b/spec/features/admin/prototypes_products_spec.rb
@@ -76,27 +76,21 @@ describe "Products", type: :feature do
       end
     end
 
-    context 'updating a product', js: true do
+    context 'updating product properties', js: true do
       let(:product) { create(:product) }
 
-      let(:prototype) do
-        size = build_option_type_with_values("size", %w(Small Medium Large))
-        FactoryBot.create(:prototype, name: "Size", option_types: [size])
-      end
-
       before do
-        @option_type_prototype = prototype
-        @property_prototype = create(:prototype, name: "Random")
+        create(:prototype, name: "Size")
+        create(:prototype, name: "Random")
       end
 
-      it 'adds option_types when selecting a prototype' do
+      it 'adds properties when selecting from a prototype' do
         visit spree.admin_product_path(product)
         click_link 'Product Properties'
         expect(page).to have_content("Select From Prototype")
         click_link "Select From Prototype"
 
-        row = find('#prototypes tr', text: 'Size')
-        row.click_link 'Select'
+        find('#prototypes tr', text: 'Size').click_link 'Select'
 
         # The following is unfortunate.
         # It is tough to distinguish between the different fields, so we assert


### PR DESCRIPTION
This PR fixes a bug introduced with https://github.com/solidusio/solidus/pull/3547 in Solidus master. 

This also takes advantage of the change to refactor the associated spec, which was a bit misleading.