### PR TITLE
Keep "Products" submenu open

### DIFF
--- a/app/overrides/decorate_admin_product_tabs.rb
+++ b/app/overrides/decorate_admin_product_tabs.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
+Spree::Backend::Config.configure do |config|
+  config.menu_items.detect { |menu_item|
+    menu_item.label == :products
+  }.sections << :prototypes
+end
+
 Deface::Override.new(
   virtual_path: "spree/admin/shared/_product_sub_menu",
-  name: "prototypes_product_tabs",
+  name: "prototypes_admin_tab",
   insert_bottom: "[data-hook='admin_product_sub_tabs']",
-  disabled: false,
-  partial: "spree/shared/prototypes_products_sub_menu_tab"
+  text: "<%= tab :prototypes if can?(:admin, Spree::Prototype) %>"
 )

--- a/app/views/spree/shared/_prototypes_products_sub_menu_tab.html.erb
+++ b/app/views/spree/shared/_prototypes_products_sub_menu_tab.html.erb
@@ -1,3 +1,0 @@
-<% if can? :admin, Spree::Prototype %>
-  <%= tab :prototypes %>
-<% end %>

--- a/spec/features/admin/prototypes_homepage_spec.rb
+++ b/spec/features/admin/prototypes_homepage_spec.rb
@@ -12,7 +12,28 @@ describe "Homepage with prototypes extension", type: :feature do
       end
 
       it "has a link to prototypes" do
-        within('.selected .admin-subnav') { page.find_link("Prototypes")['/admin/prototypes'] }
+        products_submenu = find ".selected .admin-subnav"
+
+        within products_submenu do
+          click_on "Prototypes"
+        end
+
+        within "#content-header" do
+          expect(page).to have_text "Prototypes"
+        end
+
+        within products_submenu do
+          expect(page).to have_text(
+            %w{
+              Products
+              Option Types
+              Property Types
+              Taxonomies
+              Display Order
+              Prototypes
+            }.join(" ")
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
When on the "Prototypes" admin page, the products submenu should remain open. This commit ensures that the submenu is registered properly.

## Before

<img width="522" alt="Solidus products menu is collapsed" src="https://user-images.githubusercontent.com/883581/191629212-14832f3f-4a1d-408d-b5ec-c7e68458a6bd.png">

## After

<img width="526" alt="Solidus products menu is open and the 'Prototypes' page is selected" src="https://user-images.githubusercontent.com/883581/191629247-115aaf7c-8685-4169-abd0-fd5e1e156855.png">



