### PR TITLE
Add Solidus 4.0, 4.1, 4.2 and 4.3 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-solidus_git, solidus_frontend_git = if (branch == 'master') || (branch >= 'v3.2')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
+solidus_git, solidus_frontend_git = if (branch == 'main') || (branch >= 'v3.2')
                                       %w[solidusio/solidus solidusio/solidus_frontend]
                                     else
                                       %w[solidusio/solidus] * 2

--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,19 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
-solidus_git, solidus_frontend_git = if (branch == 'main') || (branch >= 'v3.2')
+solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
+solidus_git, solidus_frontend_git = if (solidus_branch == 'main') || (solidus_branch >= 'v3.2')
                                       %w[solidusio/solidus solidusio/solidus_frontend]
                                     else
                                       %w[solidusio/solidus] * 2
                                     end
-gem 'solidus', github: solidus_git, branch: branch
-gem 'solidus_frontend', github: solidus_frontend_git, branch: branch
+solidus_frontend_branch = if (solidus_branch == 'main') || (solidus_branch >= 'v4.1')
+                            "main"
+                          else
+                            solidus_branch
+                          end
+gem 'solidus', github: solidus_git, branch: solidus_branch
+gem 'solidus_frontend', github: solidus_frontend_git, branch: solidus_frontend_branch
 
 # Needed to help Bundler figure out how to resolve dependencies,
 # otherwise it takes forever to resolve them.

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'rails', '>0.a'
 
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
+gem 'solidus_dev_support', github: "solidusio/solidus_dev_support", branch: "main"
 
 case ENV['DB']
 when 'mysql'

--- a/Gemfile
+++ b/Gemfile
@@ -4,18 +4,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
-solidus_git, solidus_frontend_git = if (solidus_branch == 'main') || (solidus_branch >= 'v3.2')
-                                      %w[solidusio/solidus solidusio/solidus_frontend]
-                                    else
-                                      %w[solidusio/solidus] * 2
-                                    end
-solidus_frontend_branch = if (solidus_branch == 'main') || (solidus_branch >= 'v4.1')
-                            "main"
-                          else
-                            solidus_branch
-                          end
-gem 'solidus', github: solidus_git, branch: solidus_branch
-gem 'solidus_frontend', github: solidus_frontend_git, branch: solidus_frontend_branch
+gem 'solidus', github: "solidusio/solidus", branch: solidus_branch
 
 # Needed to help Bundler figure out how to resolve dependencies,
 # otherwise it takes forever to resolve them.

--- a/app/assets/javascripts/spree/frontend/solidus_prototypes.js
+++ b/app/assets/javascripts/spree/frontend/solidus_prototypes.js
@@ -1,2 +1,0 @@
-// Placeholder manifest file.
-// the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/frontend/all.js'

--- a/app/assets/stylesheets/spree/frontend/solidus_prototypes.css
+++ b/app/assets/stylesheets/spree/frontend/solidus_prototypes.css
@@ -1,4 +1,0 @@
-/*
-Placeholder manifest file.
-the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/frontend/all.css'
-*/

--- a/app/overrides/decorate_admin_product_tabs.rb
+++ b/app/overrides/decorate_admin_product_tabs.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-Spree::Backend::Config.configure do |config|
-  config.menu_items.detect { |menu_item|
-    menu_item.label == :products
-  }.sections << :prototypes
-end
-
 Deface::Override.new(
   virtual_path: "spree/admin/shared/_product_sub_menu",
   name: "prototypes_admin_tab",

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -1,3 +1,18 @@
 Rails.application.config.to_prepare do
   Spree::PermittedAttributes.product_attributes << :prototype_id
+  Spree::Backend::Config.configure do |config|
+    product_tab = config.menu_items.detect { |menu_item|
+      menu_item.label == :products
+    }
+    if product_tab.respond_to?(:children)
+      product_tab.children << Spree::BackendConfiguration::MenuItem.new(
+        condition: -> { can?(:admin, Spree::Prototype) },
+        url: :admin_prototypes_path,
+        label: :prototypes,
+        match_path: '/prototypes'
+      )
+    else
+      product_tab.sections << :prototypes
+    end
+  end
 end

--- a/lib/generators/solidus_prototypes/install/install_generator.rb
+++ b/lib/generators/solidus_prototypes/install/install_generator.rb
@@ -8,12 +8,6 @@ module SolidusPrototypes
       class_option :auto_run_migrations, type: :boolean, default: false
 
       def add_javascripts
-        if SolidusSupport.frontend_available?
-          append_file(
-            'vendor/assets/javascripts/spree/frontend/all.js',
-            "//= require spree/frontend/solidus_prototypes\n"
-          )
-        end
         append_file(
           'vendor/assets/javascripts/spree/backend/all.js',
           "//= require spree/backend/solidus_prototypes\n"
@@ -21,14 +15,6 @@ module SolidusPrototypes
       end
 
       def add_stylesheets
-        if SolidusSupport.frontend_available?
-          inject_into_file(
-            'vendor/assets/stylesheets/spree/frontend/all.css',
-            " *= require spree/frontend/solidus_prototypes\n",
-            before: %r{\*/},
-            verbose: true
-          )
-        end
         inject_into_file(
           'vendor/assets/stylesheets/spree/backend/all.css',
           " *= require spree/backend/solidus_prototypes\n",

--- a/lib/generators/solidus_prototypes/install/install_generator.rb
+++ b/lib/generators/solidus_prototypes/install/install_generator.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
+require 'solidus_support'
+
 module SolidusPrototypes
   module Generators
     class InstallGenerator < Rails::Generators::Base
       class_option :auto_run_migrations, type: :boolean, default: false
 
       def add_javascripts
-        append_file(
-          'vendor/assets/javascripts/spree/frontend/all.js',
-          "//= require spree/frontend/solidus_prototypes\n"
-        )
+        if SolidusSupport.frontend_available?
+          append_file(
+            'vendor/assets/javascripts/spree/frontend/all.js',
+            "//= require spree/frontend/solidus_prototypes\n"
+          )
+        end
         append_file(
           'vendor/assets/javascripts/spree/backend/all.js',
           "//= require spree/backend/solidus_prototypes\n"
@@ -17,12 +21,14 @@ module SolidusPrototypes
       end
 
       def add_stylesheets
-        inject_into_file(
-          'vendor/assets/stylesheets/spree/frontend/all.css',
-          " *= require spree/frontend/solidus_prototypes\n",
-          before: %r{\*/},
-          verbose: true
-        )
+        if SolidusSupport.frontend_available?
+          inject_into_file(
+            'vendor/assets/stylesheets/spree/frontend/all.css',
+            " *= require spree/frontend/solidus_prototypes\n",
+            before: %r{\*/},
+            verbose: true
+          )
+        end
         inject_into_file(
           'vendor/assets/stylesheets/spree/backend/all.css',
           " *= require spree/backend/solidus_prototypes\n",

--- a/lib/solidus_prototypes/testing_support/factories.rb
+++ b/lib/solidus_prototypes/testing_support/factories.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/property_factory'
-
 FactoryBot.define do
   factory :prototype, class: 'Spree::Prototype' do
     name { 'Baseball Cap' }

--- a/solidus_prototypes.gemspec
+++ b/solidus_prototypes.gemspec
@@ -30,7 +30,8 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency "deface"
-  s.add_dependency "solidus_core", [">= 2.1.0", "< 4"]
+  s.add_dependency "solidus_backend", [">= 3.2.0", "< 5"]
+  s.add_dependency "solidus_core", [">= 3.2.0", "< 5"]
   s.add_dependency "solidus_support", "~> 0.4"
 
   s.add_development_dependency "solidus_dev_support"

--- a/solidus_prototypes.gemspec
+++ b/solidus_prototypes.gemspec
@@ -34,5 +34,4 @@ Gem::Specification.new do |s|
   s.add_dependency "solidus_support", "~> 0.4"
 
   s.add_development_dependency "solidus_dev_support"
-  s.add_development_dependency "selenium-webdriver", "< 4.8.2"
 end

--- a/spec/support/feature/base_feature_helper.rb
+++ b/spec/support/feature/base_feature_helper.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module BaseFeatureHelper
-  def click_nav(nav_text, subnav_text = nil)
-    primary_nav = find(".admin-nav-menu>ul>li>a", text: /#{nav_text}/i)
-    if subnav_text
-      primary_nav.find('+ul>li>a', text: /#{subnav_text}/i).click
+  def click_nav(nav_text)
+    if Spree.solidus_gem_version > Gem::Version.new("4.2")
+      primary_nav = find(".solidus-admin--nav--menu .tab-with-icon", text: /#{nav_text}/i)
     else
-      primary_nav.click
+      primary_nav = find(".admin-nav-menu>ul>li>a", text: /#{nav_text}/i)
     end
+    primary_nav.click
   end
 end
 


### PR DESCRIPTION
The backend menu configuration has changed in latest Solidus main branch, so we needed to adopt it.

Also this gem still tries to load solidus_frontend which fails because of the complex setup for old and new Solidus versions. Since this gem does not have any frontend code we can luckily just remove it.