### PR TITLE
Fix option_values_hash form field name name

### DIFF
--- a/app/views/spree/admin/prototypes/show.html.erb
+++ b/app/views/spree/admin/prototypes/show.html.erb
@@ -11,7 +11,7 @@
         <ul class="option-type-values">
         <% ot.option_values.each do |ov| %>
           <li>
-            <%= check_box_tag "product[option_values_hash[#{ot.id}]][]", ov.id, params[:product] && (params[:product][:option_values_hash] || {}).values.flatten.include?(ov.id.to_s), :id => "option_value_#{ov.id}", :class => "option-value" %>
+            <%= check_box_tag "product[option_values_hash][#{ot.id}][]", ov.id, params[:product] && (params[:product][:option_values_hash] || {}).values.flatten.include?(ov.id.to_s), :id => "option_value_#{ov.id}", :class => "option-value" %>
             <%= label_tag "option_value_#{ov.id}", ov.presentation %>
           </li>
         <% end %>


### PR DESCRIPTION
In Rack 3 the wrongly formatted `option_values_hash` stopped working. It was an accident that this ever worked in Rack 1 and 2

See https://github.com/rack/rack/issues/2128