### PR TITLE
Move prototype selector on top of product form

### DIFF
--- a/app/overrides/spree/admin/products/_form/prototypes_admin_products_form.html.erb.deface
+++ b/app/overrides/spree/admin/products/_form/prototypes_admin_products_form.html.erb.deface
@@ -1,4 +1,4 @@
-<!-- insert_before '[data-hook="admin_product_form_taxons"]' enabled -->
+<!-- insert_top '[data-hook="admin_product_form_left"]' enabled -->
 <% if f.object.new_record? %>
   <%= f.field_container :prototype do %>
     <%= f.label :prototype_id, Spree::Prototype.model_name.human %><br />


### PR DESCRIPTION
Move the prototype selector on top of the product form. It makes more sense to have the selection to begin with the new product instead of a selector which is in the middle of the form.

![Aufnahme 2024-04-19 at 11 48 35@2x](https://github.com/solidusio-contrib/solidus_prototypes/assets/122262394/d3a4922a-9e5a-4503-a696-f2d1a097043e)
