### PR TITLE
chore: Fix reloading in dev mode

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -1,10 +1,12 @@
 Rails.application.config.to_prepare do
-  Spree::PermittedAttributes.product_attributes << :prototype_id
+  if Spree::PermittedAttributes.product_attributes.exclude?(:prototype_id)
+    Spree::PermittedAttributes.product_attributes << :prototype_id
+  end
   Spree::Backend::Config.configure do |config|
     product_tab = config.menu_items.detect { |menu_item|
       menu_item.label == :products
     }
-    if product_tab.respond_to?(:children)
+    if product_tab.respond_to?(:children) && product_tab.children.none? { |c| c.label == :prototypes }
       product_tab.children << Spree::BackendConfiguration::MenuItem.new(
         condition: -> { can?(:admin, Spree::Prototype) },
         url: :admin_prototypes_path,
@@ -12,7 +14,9 @@ Rails.application.config.to_prepare do
         match_path: '/prototypes'
       )
     else
-      product_tab.sections << :prototypes
+      if product_tab.sections.exclude?(:prototypes)
+        product_tab.sections << :prototypes
+      end
     end
   end
 end


### PR DESCRIPTION
We need to check if the menu items are already present, otherwise during reload in dev mode new menu items will get added to the menu.