### PR TITLE
feat: Support Ruby 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,5 @@ permissions:
 jobs:
   Test:
     uses: solidusio/test-solidus-extension/.github/workflows/test.yml@v1
+    with:
+      ruby_versions: "['3.4', '4.0']"

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ when 'mysql'
 when 'postgresql'
   gem 'pg'
 else
-  gem 'sqlite3', '~> 1.7'
+  gem 'sqlite3', '~> 2.0'
 end
 
 gemspec

--- a/solidus_prototypes.gemspec
+++ b/solidus_prototypes.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Breaking out prototypes from solidus"
   s.license = "BSD-3-Clause"
 
-  s.required_ruby_version = [">= 3.0", "< 4"]
+  s.required_ruby_version = [">= 3.0", "< 5"]
 
   s.author = "Graeme Nathan"
   s.email = "graeme@stembolt.com"


### PR DESCRIPTION
Ruby 4.0 was released in December 2025, but the gemspec still capped required_ruby_version at "< 4", preventing installation on 4.x. Lift the upper bound to "< 5" and restore Ruby 4.0 to the CI test matrix so the extension is verified against it.